### PR TITLE
Fix transport parameter in load balancer Route

### DIFF
--- a/sip-servlets-impl/src/main/java/org/mobicents/servlet/sip/message/SipFactoryImpl.java
+++ b/sip-servlets-impl/src/main/java/org/mobicents/servlet/sip/message/SipFactoryImpl.java
@@ -969,6 +969,12 @@ public class SipFactoryImpl implements MobicentsSipFactory,  Externalizable {
 	public void addLoadBalancerRouteHeader(Request request, MobicentsExtendedListeningPoint mobicentsExtendedListeningPoint) {
 		try {
 			String transport = JainSipUtils.findTransport(request);
+			if ( mobicentsExtendedListeningPoint != null ) {
+				transport = mobicentsExtendedListeningPoint.getTransport();
+				if (logger.isDebugEnabled()){
+					logger.debug("addLoadBalancerRouteHeader - setting transport to " + transport + " from listening point in use");
+				}
+			}
 			String host = null;
 			int port = -1; 
 			OutboundProxy proxy = StaticServiceHolder.sipStandardService.getOutboundProxy();


### PR DESCRIPTION
If a TLS target has to be contacted, but load balancer is set to terminate TLS, the server will send the request via TCP, even though the Request-URI contains ;transport=tls. In this case, JainSipUtils.findTransport will report "tls" transport, but that is not what should be used in the Route header if a connector with a different transport is used. The Route's transport and port should match the listening point of the load balancer, which will be TCP in this case.